### PR TITLE
Escape variable names in regex to fix unbalanced parenthesis

### DIFF
--- a/sanitizer/State_machine_instrument.py
+++ b/sanitizer/State_machine_instrument.py
@@ -158,7 +158,8 @@ def instrument(enum_variable_uniq):
                 with open(os.path.join(root, file), 'r+', encoding="utf-8", errors='ignore') as f:
                     content = f.read()
                     for name in enum_variable_uniq:
-                        result = search_index("^(?: |\t)*?(?:\w+\.|\w+->)*?" + name+" ?= ?\w+?;", content)
+                        safe_name = re.escape(name)
+                        result = search_index("^(?: |\t)*?(?:\w+\.|\w+->)*?" + safe_name +" ?= ?\w+?;", content)
                         content = package_content(content, result, file, root)
                     if not debug:
                         f.seek(0)


### PR DESCRIPTION
- Introduced `safe_name = re.escape(name)` in `State_machine_instrument.py` to ensure that any special characters in enum variable names do not break the regular expression.
- This fixes the 'unbalanced parenthesis' error when processing certain variable names.